### PR TITLE
Corrected a little typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To download `fastEmu`, use the code below.
 ``` r
 # install.packages("devtools")
 devtools::install_github("statdivlab/fastEmu")
-library(radEmu)
+library(fastEmu)
 ```
 
 ## Use


### PR DESCRIPTION
In the Installation section, it said to call `library(radEmu)`, but I believe it should say `library(fastEmu)`